### PR TITLE
remove trailing '-' from page and post basenames

### DIFF
--- a/lib/string.sh
+++ b/lib/string.sh
@@ -6,7 +6,7 @@ trim() {
 
 # convert string to hook
 slug() {
-    tr -cd '[:alnum:][:space:]' <<< "$*" | tr -s '[:space:]' - | tr '[:upper:]' '[:lower:]'
+    tr -cd '[:alnum:][:space:]' <<< "$*" | tr -s '[:space:]' - | tr '[:upper:]' '[:lower:]' | sed -e 's|-$||'
 }
 
 html_escape() {


### PR DESCRIPTION
New pages and posts had an extra '-' in the basename of the markdown
files (at least it does on my version of bash in Debian Linux).  This
fix removes the '-'; i.e.,

'<some-post-name>-.md'  is now  '<some-post-name>.md'